### PR TITLE
Corrected "bugfix" to "master" under merge conflict section

### DIFF
--- a/assignments/lab/lab1-git/README.md
+++ b/assignments/lab/lab1-git/README.md
@@ -437,7 +437,7 @@ Once we have resolved this merge conflict, we can finalize our merge.  We first 
 
 ```
 $ git add main.cpp
-$ git commit -m "solved merge conflict between userinput and bugfix branches"
+$ git commit -m "solved merge conflict between userinput and master branches"
 ```
 
 And your tree looks like:


### PR DESCRIPTION
The merge that caused the conflict was requested from master branch to userinput branch, not from the bugfix branch.
