### PR TITLE
calc grade now installs instructor keys

### DIFF
--- a/scripts/calcgrade.sh
+++ b/scripts/calcgrade.sh
@@ -18,6 +18,11 @@ if [ -z $user ]; then
 fi
 
 #######################################
+# check if user has installed keys
+
+checkKeys
+
+#######################################
 # calculate stats
 
 echo "finding grade for github account $user"

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -42,6 +42,29 @@ while [ ! -e "LICENSE" ]; do
     cd ..
 done
 
+##########################################
+#checks if keys are installed
+checkKeys()
+{
+    local TMPFILE="REMOVE_ME.tmp"
+    for INST in people/instructors/*;do
+        local STR=${INST##*/}
+        if [[ $STR == *@* ]];then
+            gpg --list-keys $STR  > $TMPFILE 2> $TMPFILE
+            if [ ! $? -eq 0 ] ;then
+                colorPercent "50"
+                echo "Instructor keys were not installed! Installing..."
+                resetColor
+                scripts/./install-instructor-keys.sh
+                colorPercent 100
+                echo "------Done installing keys------"
+                resetColor
+            fi
+        fi
+    done
+    rm $TMPFILE
+}
+
 #######################################
 # misc display functions
 


### PR DESCRIPTION
checkKeys iterates through all instructor files that have an @ symbol (email). all output from checking if the instructor's keys are installed is placed into a temporary file that is deleted after the loop. if the instructor key is not installed, then checkKeys calls install-instructor-keys to install the keys.
