### PR TITLE
addgrader.sh will now run more universally

### DIFF
--- a/scripts/addgrader.sh
+++ b/scripts/addgrader.sh
@@ -20,6 +20,26 @@ if [ -z "$email" ] || [ -z "$name" ]; then
     echo "ERROR: either name or email is not configured; please run the commands:"
     echo " $ git config --global user.name \"your name here\""
     echo " $ git config --global user.email \"your email here\""
+    exit
+fi
+
+#######################################
+
+output="$instructorinfo/$email"
+gitKey=$(git config --get user.signingkey)
+if [ ! -z "$gitKey" ]; then #git signingkey exists
+    if ( includesKey $output $gitKey ); then
+        echo "Key already exists and is in class repository. Nothing to be done"
+        exit
+    else
+        echo "Key already exists. Exporting key to $output"
+        gpg --export "$gitKey" >> "$output"
+        echo "Adding key to class repository"
+        git add "$output"
+        git commit -m "added instructor $name <$email> to class"
+        git push origin
+        exit
+    fi
 fi
 
 #######################################
@@ -41,9 +61,8 @@ git config user.signingkey "$key"
 #######################################
 
 echo ""
-output="$instructorinfo/$email"
 echo "exporting new key to $output"
-gpg --export "$email" >> "$output"
+gpg --export "$key" >> "$output"
 echo "adding key to class repository"
 git add "$output"
 git commit -m "added instructor $name <$email> to class"

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -442,4 +442,3 @@ checkKeys()
         fi
     done
 }
-


### PR DESCRIPTION
If you have a signing key and it's already in the repository, it will not do anything.
If you have a signing key and it's not in the repository, it will add the key to the repository.
If you don't have a signing key, it will generate a new key as it did before.

Keys existing in the repository will no longer get overwritten.

fixed conflicts
