### PR TITLE
checksyscalls now checks for lstat

### DIFF
--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -43,6 +43,7 @@ syscalls="
     closedir
     readdir
     readdir_r
+    lstat
     stat
     pipe
     dup2


### PR DESCRIPTION
checksyscalls was not checking for lstat and resulted in having more perrors then syscalls.
