### PR TITLE
Checksyscalls improvements and calcgrade fix

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -38,9 +38,9 @@ function failScript {
 
 # cd to the repo's root folder by backtracking until we find the LICENSE file
 # this let's the scripts be run from any folder in the repo
-#while [ ! -e "LICENSE" ]; do
-    #cd ..
-#done
+while [ ! -e "LICENSE" ]; do
+    cd ..
+done
 
 #######################################
 # misc display functions


### PR DESCRIPTION
1: Checksyscalls can take in folder arguments(with or without trailin$
2: Modified the regular expressions so that open now does not match f$
3: Added sycalls ioctl, close and readlink to the list.
4: Renintroduced the config.sh backtrace to home
5: fixed paths to rmcomments.sh to fix the original bug
# Hope that everything works now
