### PR TITLE
Checksyscalls improvements and calgrade fix

### DIFF
--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -10,8 +10,8 @@
 # by a parenthesis.  This should never overcount syscalls, but could undercount
 # them in the presence of macros, function pointers, or other fanciness.
 #
-scriptdir=`dirname "$0"`
-source "$scriptdir/config.sh"
+#scriptdir=`dirname "$0"`
+#source "config.sh"
 
 if [ $# -eq 0 ]; then
     echo "usage: $0 filetograde"
@@ -20,7 +20,7 @@ elif [ $# -eq 1 ];then
     if [ -d $1 ]; then
         for s in "$1"/*
         do
-            /bin/bash $scriptdir/checksyscalls.sh $s
+            ./checksyscalls.sh $s
         done
         exit 0
     fi
@@ -30,17 +30,19 @@ else
         if [ -d $f ]; then
             for g in "$f"/*
             do
-                /bin/bash $scriptdir/checksyscalls.sh $g
+                ./checksyscalls.sh $g
             done
         else
-            /bin/bash $scriptdir/checksyscalls.sh $f
+            ./checksyscalls.sh $f
         fi
     done
     exit 0
 fi
 
+source "config.sh"
+
 # we'll pipe files through these commands to remove spurious counts
-rmcomments="$scriptdir/rmcomments.sh"
+rmcomments="./scripts/rmcomments.sh"
 rmstr="sed s/\"[^\"]*\"//g"
 rminclude="sed s/#.*//"
 

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -38,9 +38,9 @@ function failScript {
 
 # cd to the repo's root folder by backtracking until we find the LICENSE file
 # this let's the scripts be run from any folder in the repo
-#while [ ! -e "LICENSE" ]; do
-    #cd ..
-#done
+while [ ! -e "LICENSE" ]; do
+    cd ..
+done
 
 #######################################
 # misc display functions


### PR DESCRIPTION
1: Checksyscalls takes in folder arguments(with or without trailing /) and goes recursively through all folders.
2: Modified the regular expressions so that open now does not match filestream member function like ifs.open("file").
3: Added sycalls ioctl, close and readlink to the list.
