### PR TITLE
added getenv to checksyscall script

### DIFF
--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -83,6 +83,7 @@ syscalls="
     sigaction
     getpwuid
     getgrgid
+    getenv
     "
 
 #The regex will not match member operators like stream::open.


### PR DESCRIPTION
`getenv` was not checked in the check system call script, which resulted in more perrors than system calls. 
