### PR TITLE
Added some new syscalls to check

### DIFF
--- a/scripts/checksyscalls.sh
+++ b/scripts/checksyscalls.sh
@@ -55,6 +55,7 @@ syscalls="
     execle
     execlp
     execv
+    execve
     execvl
     execvp
     fork
@@ -78,11 +79,14 @@ syscalls="
     chdir
     getcwd
     getwd
-    get_current_directory_name
+    get_current_dir_name
     signal
     sigaction
     getpwuid
     getgrgid
+    kill
+    access
+    system
     "
 
 #The regex will not match member operators like stream::open.


### PR DESCRIPTION
- `get_current_directory_name` was checking for a non-existent syscall. 

Added: 
- `execve`
- `kill`: pretty important to check that this didn't fail. Otherwise we have `zombies` D: 
- `access`: In hw3, probably not a nice solution if it was used, but just in case. I know I've used this in the past. Perhaps not successfully and without any error checking. 
- `system`: I imagine we shouldn't be using this in our assignments. As a check that we are not, the instructors can simply see if it is one of the listed syscalls through `checksyscalls.sh`, see if it is at least error checked, then go from there. If you think it is necessary, I can modify `checksyscalls.sh` to include more useful information when `system` is used. For example, "`system` has been used!! Automatic [insert score here]".
  edit: checking whether or not `system` is used through macros is another story. It would be something fun to play around with. 
