### PR TITLE
Updated piping section for syscalls tutorial

### DIFF
--- a/tutorials/syscalls/README.md
+++ b/tutorials/syscalls/README.md
@@ -239,6 +239,8 @@ Now that we’ve gone over the basics of what piping is we can talk about how to
  
 Here’s an example of `pipe` in action:
 ```
+const int PIPE_READ = 0;
+const int PIPE_WRITE = 1;
 int fd[2];
 if(pipe(fd) == -1)//call to pipe, it puts the read end and write end file descriptors in fd
    perror("There was an error with pipe(). ");
@@ -249,44 +251,63 @@ if(pid == -1)//fork’s return value for an error is -1
    perror("There was an error with fork(). ");
    exit(1);//there was an error with fork so exit the program and go back and fix it
 }
-else if(pid == 0)//when pid is 0 you are in the child process
+else if(pid == 0)//when pid is 0 you are in the first child process
 {
-   cout<<"This is the child process ";
+   cout<<"This is the first child process ";
 
    //write to the pipe
-   if(-1 == dup2(fd[1],1))//make stdout the write end of the pipe 
+   if(-1 == dup2(fd[PIPE_WRITE],1))//make stdout the write end of the pipe 
       perror("There was an error with dup2. ");
-   if(-1 == close(fd[0])//close the read end of the pipe because we're not doing anything with it right now
+   if(-1 == close(fd[PIPE_READ])//close the read end of the pipe because we're not doing anything with it right now
       perror("There was an error with close. ");
 
    if(-1 == execvp(argv[0], argv)) 
       perror("There was an error in execvp. ");
 
 
-   exit(1);  //when the child process finishes doing what we want it to, cout, we want to kill the child process so it doesn’t go on in the program so we exit
+   exit(1);  //prevents zombie process
 }
-//if pid is not 0 then we’re in the parent
-else if(pid > 0) //parent function
+//if pid is not 0 then we’re in the first parent
+else if(pid > 0) //first parent function
 {
    //read end of the pipe
    int savestdin;
    if(-1 == (savestdin = dup(0)))//need to restore later or infinite loop
       perror("There is an error with dup. ");
-   if(-1 == dup2(fd[0],0))//make stdin the read end of the pipe 
-      perror("There was an error with dup2. ");
-    if(-1 == close(fd[1])//close the write end of the pipe because we're not doing anything with it right now
-      perror("There was an error with close. ");
    if( -1 == wait(0)) //wait for the child process to finish executing
-      perror(“There was an error with wait().);
+      perror(“There was an error with wait(). ");
+   
+   int pid2 = fork();
+   if(pid2 == -1)//fork's return value for an error is -1
+   {
+      perror("There was an error with fork(). ");
+      exit(1);//there was an error with fork so exit the program and go back and fix it 
+   }
+   else if(pid2 == 0)//when pid2 is 0 you are in the second child process
+   {
+      cout << "This is the second child process ";
 
-   //here you have to do another fork to execute the right side of the pipe command, as in the above example (“names | sort”) you would execute the sort command, we will leave this as an example for you to do.
+      if(-1 == dup2(fd[PIPE_READ],0))//make stdin the read end of the pipe 
+         perror("There was an error with dup2. ");
+      if(-1 == close(fd[PIPE_WRITE])//close the write end of the pipe because we're not doing anything with it right now
+         perror("There was an error with close. ");
 
+      if(-1 == execvp(argv2[0], argv2))
+         perror("There was an error in excecvp. ");
+
+      exit(1); //prevents zombie process
+   }
+   else if(pid2 > 0) //second parent function
+   {
+      if(-1 == wait(0)) //wait for the child process to finish executing
+         perror("There was an error with wait(). ");
+   }
 }
 if(-1 == dup2(savestdin,0))//restore stdin
    perror("There is an error with dup2. ");
 ```
 
-Here we see the full use of the `pipe` syscall. When we call `pipe` we have our `int fd[2]` as the parameter, `pipe` populates this array with the file descriptors of the read and write end of the imaginary file that is created. Then we `fork` the process, and in the child we change the stdout of whatever you are running to the write end of the imaginary file. In our example of `names|sort` the output of our names executable will be the input of our file. Then we go to our parent function and set the stdin to the read end of the `pipe`. We do this because we want the thing we wrote to the imaginary file to be the input to the right side of the pipe. In our example `names|sort` we want the names output to be the input of the sort program. After this we have to immediately call another `fork` function to execute the right side of the pipe. For this we have to call a function that is similar to the `exec` example, we will leave this as a workable example for you.
+Here we see the full use of the `pipe` syscall. When we call `pipe` we have our `int fd[2]` as the parameter, `pipe` populates this array with the file descriptors of the read and write end of the imaginary file that is created. Then we `fork` the process, and in the child we change the stdout of whatever you are running to the write end of the imaginary file. In our example of `names|sort` the output of our names executable will be the input of our file. Then we go to our parent function and set the stdin to the read end of the `pipe`. We do this because we want the thing we wrote to the imaginary file to be the input to the right side of the pipe. In our example `names|sort` we want the names output to be the input of the sort program. After this we have to immediately call another `fork` function to execute the right side of the pipe.
 
 ##getcwd:
 


### PR DESCRIPTION
Fixed an error with quotations (previously in line 280), added explicit implementation of second fork, and added global variables `PIPE_READ` and `PIPE_WRITE` for clarity.
