### PR TITLE
fix to lab1 (1)

### DIFF
--- a/assignments/lab/lab1-git/README.md
+++ b/assignments/lab/lab1-git/README.md
@@ -519,7 +519,7 @@ Click the button on the left hand side labeled `collaborators`:
 
 This should bring up a menu that lets you add collaborators.  Everyone you add here has full write access to the repo.  Add all of the course instructors as collaborators.  Our GitHub accounts are: `MikeIzbicki`, `busrac`, and `benavidz`.
 
-**IMPORTANT:** The file <a href="../../../GRADES.md">GRADES.md</a> in this repo contains detailed information about how your grades will be stored in this repo.  Finish completing this lab, then go back and read this file.
+**IMPORTANT:** The file <a href="https://github.com/mikeizbicki/gitlearn">README.md</a> in the gitlearn repo contains detailed information about how your grades will be stored in this repo.  Finish completing this lab, then go back and read this file.
 
 ### add your information to the course page
 


### PR DESCRIPTION
link changed,
GRADES.md -> README.md
lab says 'grades-stutff' is in same repo -> lab says 'grades-stuff' is in gitlearn repo
