### PR TITLE
Added prefix "octal" on XOR operation description for clarity.

### DIFF
--- a/textbook/assignment-help/bitwise-ops/README.md
+++ b/textbook/assignment-help/bitwise-ops/README.md
@@ -386,7 +386,7 @@ The truth table for the XOR operation is:
 	</TR>
 </TABLE>
 
-Looks like it's time for another example! Let’s perform the XOR operation on 015 and 023:
+Looks like it's time for another example! Let’s perform the XOR operation on octal values 015 and 023:
 ```
     015 ^ 023 //Ah yes, use their bit representations!
 


### PR DESCRIPTION
Adding for clarity as the author originally used decimal values for the AND bitwise operator example, and then switched back to octal values for the XOR bitwise operator example. This may cause confusion.
