### PR TITLE
Fix warnings

### DIFF
--- a/assignments/hw/hw1-ls/ls.cpp
+++ b/assignments/hw/hw1-ls/ls.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 int main()
 {
-    char *dirName = ".";
+    char dirName[] = ".";
     DIR *dirp = opendir(dirName);
     dirent *direntp;
     while ((direntp = readdir(dirp)))


### PR DESCRIPTION
Declaring `dirName` as `char*` throws warnings that turn into errors when compiled with `-ansi -pedantic -Wall -Werror`
