### PR TITLE
typo in getgrgid syscall implementation

### DIFF
--- a/textbook/assignment-help/syscalls/getinfo.md
+++ b/textbook/assignment-help/syscalls/getinfo.md
@@ -82,7 +82,7 @@ The main purpose of this function is to assist in finding info about the group a
 
 Here’s a quick implementation of `getgrgid`, where s is a `stat struct`:
 ```
-struct passwd *gp;
+struct group *gp;
 if(!(gp = getgrgid(s.st_gid)))
    perror("there was an error in getgrgid. ");
 ```


### PR DESCRIPTION
Fixed to maintain consistency with previously mentioned group struct in line 73
