### PR TITLE
HW1, HW2, and lab 5 related Syscalls HW4 Submission

### DIFF
--- a/assignments/lab/lab5-cp/README.md
+++ b/assignments/lab/lab5-cp/README.md
@@ -27,3 +27,11 @@ In order to determine which method is fastest, you'll need to test them on a lar
 The deliverables for this lab are more complicated than for previous labs.  We want your `cp` program added to your `rshell` project on github.  Source code should go in the `src` folder, and the `Makefile` needs to be modified to build the `cp` program and put it in the `bin` folder.  This is the same setup we had for the `ls` command you wrote for homework. 
 
 There is one catch though: you are not allowed to commit the code to your own repository.  Your partner must fork your repo, commit the code, and issue a pull request making all the changes.  I want you to get practice contributing to other people's open source projects and having other people contribute to your own projects.
+
+##additional resources
+Read the man pages on `open()`, `read()`, `write()`, and `close()` for further information on manipulating file descriptors and buffers.
+
+Here is a complete list of resources created by previous cs100 students that might help with this lab:
+
+* [Syscalls on file descriptors](../../../textbook/assignment-help/syscalls/fd.md)
+* [Bitwise Operators](../../../textbook/assignment-help/bitwise-ops/README.md)

--- a/textbook/assignment-help/bitwise-ops/README.md
+++ b/textbook/assignment-help/bitwise-ops/README.md
@@ -1,11 +1,12 @@
 ##Introduction to Bitwise Operators
 
-Hey you! Yea, you! Do you want to learn about bitwise operators? Well, it doesn't matter what you want because you're going to learn them anyway! And do you know why? It's so you can do stuff like this:
+Hey you! Yea, you! Do you want to learn about bitwise operators? Well, it doesn't matter what you want because you're going to learn them anyway! And do you know why? It's so you can use system calls like this:
 
 ```
  int fd = open("filename", O_WRONLY | O_APPEND, S_IRUSR | S_IWUSR);
 ```
-Whoa what's the vertical bar thing? That's the bitwise `OR` operator, one of the bitwise operators you will learn about! Here, we pass in multiple flags to the `open` [system call](http://linux.die.net/man/2/open). "But it only takes in 2 `int` values. How did you pass in more than one flag/macro each?" The secret is the `OR` operator: the `OR` operator combines the flags into one value that we then pass in. 
+
+Whoa what's the vertical bar thing? That's the bitwise `OR` operator, one of the bitwise operators you will learn about! Here, we pass in multiple flags to the `open` [system call](http://linux.die.net/man/2/open). While we won't cover more than just its argument flags in this tutorial, some CS100 students have done so already [here](../syscalls/fd.md)! Back to the observation! "But it only takes in 2 `int` values. How did you pass in more than one flag/macro each?" The secret is the `OR` operator: the `OR` operator combines the flags into one value that we then pass in. 
 
 But wait! Did you notice how `open` had `int` parameters? That's right, these flags and macros are nothing more than a bunch of integers! This means that we could actually just memorize the number for every single flag combination in every library. Then we wouldn't need to use bitwise operators! Of course, that's super impractical, which is why we have the bitwise operators. We just need to look up the macro names, and the bitwise operators can take care of the rest, no memorization needed. Let's get started!
 

--- a/textbook/assignment-help/syscalls/README.md
+++ b/textbook/assignment-help/syscalls/README.md
@@ -2,7 +2,9 @@
 
 Within this folder, you will find tutorials on functions that will be useful when programming your own shell.  These functions are called system calls, or syscalls, and they differ from regular functions because a syscall requests a specific service from the operating system’s kernel.
 
-All system calls will be described in their respective files, but there will be a brief description of what each does here. exec.md will explain system calls relating to `exec` and includes `fork`, `wait`, and `exec`. io.md will include system calls that relate to input and output redirection and include `dup` and `pipe`. Lastly, getinfo.md will include system calls that retrieve information about a process or environment variable. These include `getcwd`, `getpwuid`, and `getgrgid`.
+All system calls will be described in their respective files, but there will be a brief description of what each does here. exec.md will explain system calls relating to `exec` and includes `fork`, `wait`, and `exec`. io.md will include system calls that relate to input and output redirection and include `dup` and `pipe`. dir.md covers the three system calls `opendir`, `readdir`, and `closedir` which solely deal with directory access and properties. stat.md will explain the system calls related to gathering all the collective info on a file, including  `stat`, `fstat`, `lstat`. getinfo.md will include system calls that retrieve information about a process or environment variable. These include `getcwd`, `getpwuid`, and `getgrgid`. Lastly, the file `fd.md` covers files related to manipulating file descriptors: `open`, `read`, `write`, and `close`.
+
+Also included are demonstrations which walk through the reasoning behind the structure of some of these code blocks, and why they're used in conjunction with these system calls to achieve a greater goal. Currently, `dir.md` and `fd.md` each have their own `_demo` files with the `stat.md` housing its own demonstration.
 
 `exec`: will execute a file
 
@@ -14,11 +16,31 @@ All system calls will be described in their respective files, but there will be 
 
 `pipe`: creates a pipe, or data channel for communication
 
+`opendir`: creates a pointer to a stream of a directory's entries
+
+`readdir`: access a directory's entries' properties
+
+`closedir`: close the stream to a directory's entries
+
+`stat`: gets information about a passed in file
+
+`fstat`: gets information about a file passed in by a file descriptor
+
+`lstat`: gets information about a passed in file or symbolic link, depending on what was passed in
+
 `getcwd`: gets the current working directory
 
 `getpwuid`: gets information about a passed in username
 
 `getgrgid`: gets information about a group which matches a passed in group ID
+
+`open`: creates a file descriptor to a file
+
+`read`: adds to a file descriptor or buffer the contents of a passed in file descriptor
+
+`write`: adds to a file descriptor the contents of another file descriptor or buffer
+
+`close`: closes the passed in file descriptor, sealing all changes made to it
 
 The only function we will discuss in this README will be `perror`, an error checking function which should be used with every system call.
 

--- a/textbook/assignment-help/syscalls/dir.md
+++ b/textbook/assignment-help/syscalls/dir.md
@@ -1,0 +1,111 @@
+#System Calls related to Obtaining Information on Directories
+
+This file contains information on the system calls needed to gather information from directories and its contents. In combination, these system calls will allow the user to open/close directories as streams and search through the properties of each file within said directory. The system calls that follow are `opendir`, `readdir`, and `closedir`.
+
+##opendir
+
+**includes:** `#include <sys/types.h>`, `#include <dirent,h>`
+
+**declaration:** `DIR *opendir(const char *name);`
+			`DIR *fdopendir(int fd);`
+
+**returns:** Returns a pointer to a stream of the directory passed in. Returns a `NULL` if an error occurred.
+
+[man page](http://linux.die.net/man/3/opendir)
+
+The system call `opendir` grants access to a stream of data type DIR related to the directory that was passed in the arguments. From there, system calls like `readdir` can be used to access the contents of the directory within the stream.
+
+An example of using the `opendir` system call:
+```
+DIR *dirp; //Allocate data for the stream
+if(NULL == (dirp = opendir(dirName)))
+{
+	perror("There was an error with opendir(). ");
+	exit(1); //Permission to directory denied, or invalid directory
+}
+```
+
+##readdir
+
+**includes:** `#include <dirent,h>`
+
+**declaration:** `struct dirent *readdir(DIR *dirp);`
+			`int readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result);`
+
+**returns:** Returns a pointer to the next directory entry within the `DIR` stream that was passed in. Returns a `NULL` if the function has reached the end of a directory stream or if an error occurred.
+
+[man page](http://linux.die.net/man/3/readdir)
+
+The system call `readdir` reads into the `DIR` stream created from `opendir` to produce a `dirent` struct containing specific info about the files or directories within the stream. The attributes of the `dirent` struct include:
+```
+struct dirent
+{
+	ino_t			d_ino;		 /* inode number*/
+	off_t			d_off;		 /* not an offset; see NOTES */
+	unsigned short	d_reclen;	 /* length of this record */
+	unsigned char	d_type;		 /* type of file; not supported
+								    by all filesystem types */
+	char			d_name[256]; /* filename */
+
+}
+```
+`readdir` can be called again on the same `DIR` stream to overwrite its previous contents with the next directory entry in the stream.
+
+An example of using the `readdir` system call to parse through an entire directory, given `DIR` stream `dirp`:
+```
+struct dirent *filespecs; //Allocate data for the dirent struct
+int errcheck; //Error value for error checking
+while(filespecs = readdir(dirp))
+{
+	errcheck = errno;
+	if(errcheck == -1)
+	{
+		perror("There was an error with readdir(). ");
+		break; //Reached end of directory or invalid directory stream
+	}
+	//Access dirent struct attributes here, such as gathering a file name
+}
+```
+##closedir
+
+includes:** `#include <sys/types.h>`, `#include <dirent.h>`
+
+**declaration:** `int closedir(DIR *dirp);`
+
+**returns:** Returns a 0 on success. Otherwise, returns -1 if an error occurred.
+
+[man page](http://linux.die.net/man/3/closedir)
+
+The system call `closedir` closes the associated `DIR` stream passed in to the system call. Closing `DIR` streams save memory-related resources and prevent unexpected behavior by using data from a previous `DIR` stream.
+
+An example of using the `closedir` system call after using `opendir` and `readdir`:
+```
+DIR *dirp; //Allocate data for the stream
+if(NULL == (dirp = opendir(dirName)))
+{
+	perror("There was an error with opendir(). ");
+	exit(1); //Permission to directory denied, or invalid directory
+}
+struct dirent *filespecs; //Allocate data for the dirent struct
+int errcheck; //Error value for error checking
++while(filespecs = readdir(dirp))
+{
+	errcheck = errno;
+	if(errcheck == -1)
+	{
+		perror("There was an error with readir(). ");
+		break; //Reached end of directory or invalid directory stream
+	}
+	//Access dirent struct attributes here, such as gathering a file name
+}
+
+if(-1 == closedir(dirp))
+{
+	perror("There was an error with closedir(). ");
+	exit(1); //Invalid DIR stream
+}
+```
+
+##Additional Resources
+
+* [Demonstration: Obtaining Information on Directories](./dir_demo.md)

--- a/textbook/assignment-help/syscalls/dir_demo.md
+++ b/textbook/assignment-help/syscalls/dir_demo.md
@@ -1,0 +1,99 @@
+#Demonstration: Obtaining Information on Directories
+
+This file contains a piece of code that demonstrates how to open a directory, print the name of each file in the directory, and then close said directory upon reaching its end. The code utilizes the system calls `opendir`, `readdir`, and `closedir`, as well as several streams and structs unique to these system calls, directories, and their contents. The code without any commentary is shown below, with follow-up snippets of code to explain the process and system calls used in relation with the code.
+
+##Code
+
+```
+DIR *dirp;
+if(NULL == (dirp = opendir(dirName)))
+{
+	perror("There was an error with opendir(). ");
+	exit(1);
+}
+struct dirent *filespecs;
+int errcheck;
+while(filespecs = readdir(dirp))
+{
+	errcheck = errno;
+	if(errcheck == -1)
+	{
+		perror("There was an error with readir(). ");
+		break;
+	}
+	cout << filespecs->d_name << " ";
+}
+cout << endl;
+
+if(-1 == closedir(dirp))
+{
+	perror("There was an error with closedir(). ");
+	exit(1);
+}
+```
+
+##Explanation
+
+We begin by first allocating some memory that will be utilized with all three system calls used in this demo: the `DIR` data type. It acts as a stream to the contents of any directory passed into `opendir`, which we call next. Note that the call to `opendir` will only succeed and fill the `DIR` stream if a valid directory is passed in as its sole argument, otherwise it will return the `NULL` value to the stream. The "failed" state of the `DIR` stream is a factor we can use for error checking.
+
+```
+DIR *dirp; //Allocate data for the directory stream
+if(NULL == (dirp = opendir(dirName))) //Opendir will place the contents of dirName into the dirp stream or NULL if dirName is invalid
+{
+	perror("There was an error with opendir(). ");
+	exit(1); //Permission to directory denied, wrong directory name, not a directory
+}
+```
+
+Now that we have the `DIR` stream `dirp` filled, we can use the system call `readdir` on it to extract individual file information from it. While `readdir` uses the stream as an argument, it returns a pointer to another data structure that holds the information of a specific file within the directory. We must allocate memory of the `struct dirent` to access the info that `readdir` will return.
+
+```
+struct dirent *filespecs; //Allocate data for the dirent struct for readdir
+int errcheck; //Error value for error checking
+while(filespecs = readdir(dirp)) //readdir will overwrite the previous directory entry with the next entry until the end of the directory
+{
+	errcheck = errno; 
+	if(errcheck == -1)
+	{
+		perror("There was an error with readdir(). ");
+		break; //Reached end of directory or invalid directory stream
+	}
+	cout << filespecs->d_name << " "; //Access file specifics here, such as printing out the file-name
+}
+cout << endl;
+```
+
+In this moment of the code, we use a loop to repeatedly call `readdir` due to the way `readdir` is built. If called onto the same structure and with the same directory, `readdir` will overwrite what would be in `filespecs` with the next file in the directory until it exhausts the stream, returning a `NULL` to indicate the end of a directory. We use the `errno` value to track when `readdir` ends, but there are certainly other ways to cover a stream with `readdir`.
+
+As `filespecs` is a struct, it contains its own values that `readdir` will update according to the file that is currently passed into `readdir` on the `DIR` stream The attributes of the struct include:
+
+```
+struct dirent
+{
+	ino_t			d_ino;		 /* inode number*/
+	off_t			d_off;		 /* not an offset; see NOTES */
+	unsigned short	d_reclen;	 /* length of this record */
+	unsigned char	d_type;		 /* type of file; not supported
+								    by all filesystem types */
+	char			d_name[256]; /* filename */
+
+}
+```
+
+When within the `readdir` loop, it is possible to do far more with the struct values than just printing the file-name out. You can save wanted attributes to other data structures like vectors, and use them in conjunction with other system calls like `stat` to access even more specifics about the file itself.
+
+When we are done looking through a directory, it is always good practice to close the directory to return and conserve precious memory. Closing a directory uses `closedir`, and is relatively simple as it takes in the `DIR` stream, and returns a value to indicate whether it succeeded or not.
+
+```
+if(-1 == closedir(dirp)) //Close the DIR stream when we're finished
+{
+	perror("There was an error with closedir(). ");
+	exit(1);
+}
+```
+
+##Follow-Up
+
+This demonstration only covers the use of the `opendir`, `readdir`, and `closedir` system calls to access and search through a directory. Further documentation can be found here:
+* [System Calls related to Obtaining Information on Directories](./dir.md)
+

--- a/textbook/assignment-help/syscalls/fd.md
+++ b/textbook/assignment-help/syscalls/fd.md
@@ -1,0 +1,154 @@
+#System Calls related to Manipulating File Descriptors
+
+This file contains information on the system calls needed to manipulate file descriptors in general. In combination, these system calls will ultimately allow the writer to create or add on to files with code. The system calls that follow are `open`, `read`, `write`, and `close`.
+
+##open
+
+**includes:** `#include <sys/types.h>, `#include <sys/stat.h>`, `#include <fcntl.h>`
+
+**declaration:** `int open(const char *pathname, int flags);`
+			`int open(const char *pathname, int flags, mode_t mode);`
+			`int creat(const char *pathname, mode_t mode);`
+
+**returns:** Returns the value of the new file descriptor, or -1 if an error occurred.
+
+[man page](http://linux.die.net/man/2/open)
+
+The `open` system call takes in a name for an existing or non-existent file and returns an associated file descriptor to that file. The file descriptor can then be used with other system calls to change its contents and reflect those changes to the file it originated from. It can be seen as an editable form of the file identified by an integer value. Note that `open` will assign the file descriptor the next available file descriptor value in the kernel.
+
+`open` cannot be used without also passing in flags that determine the end-goals of the file descriptor it returns. Looking to simply open a file to use its contents? The flag macro `O_RDONLY` returns a file descriptor that does that. Looking to create a new file from nothing? The flag macros `O_CREAT` coupled with `O_WRONLY` returns a file descriptor that does that. Looking to add on to an existing file? The flag macros `O_APPEND` and `O_WRONLY` returns a file descriptor that does that. 
+
+As `open` only takes in three arguments, how would we fit multiple flags into just one argument? Simply line them up in one argument, and separate each flag with bitwise operator `|`.
+
+There are 2 types of flags to consider: the access mode, and the creation/status flag. Both of these are essential to open functioning as intended and determining what open will do. The access mode asks for access to a file, requesting permissions that are defined by the macros `O_RDONLY`(read), `O_WRONLY`(write), and `O_RDWR`(read/write). The creation/status flag tells open what the file descriptor should do after it is closed. There are many flags to cover, but this file will only cover the two used in the scope of this class. The creation flag `O_CREAT` tells the file descriptor to create a file on end, regardless if the file exists or not. If the file exists, then all content in the file would be overwritten for the new created content. The status flag `O_APPEND` opens the file descriptor to add on to the root file, attaching all content in the file descriptor to the very end of the root file. The status flag `O_TRUNC` takes an existing file(if any), and overwrites all data within that file with the contents of the file descriptor upon closing.
+
+An example of using `open` to create a new file descriptor to a new file is shown below:
+```
+int fd; //We need an integer to place the file descriptor somewhere for future use
+if(-1 == (fd = open("testfile", OWRONLY | O_CREAT)))
+{
+	perror("There was an error with open(). ");
+	exit(1); //The file already exists
+}
+```
+Just because we created a new file does not mean it has any permissions attached to it! As is, this code will create a file with no actual permissions, meaning nobody will be able to access the file generated! With the `O_APPEND` flag it is possible to get by without including a third argument as those entail the permissions of the file as they already exist. For creation(`O_CREAT`) flags however, it is mandatory that they are included or else the file created will be inaccessible to anyone.
+
+These permissions exist as octal values conveniently assigned to macros for use. This tutorial will only cover the ones used in the scope of this file, and the rest may be looked up in the man page. These mode flags can be linked together with bitwise operator `|` like the mode access and creation/status flags.
+```
+S_IRUSR 00400	user has read permission
+S_IWUSR 00200	user has write permission
+```
+
+With our newfound knowledge, we can now properly open a file descriptor to a file:
+```
+int fd; //We need an integer to place the file descriptor somewhere for future use
+if(-1 == (fd = open("testfile", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR)))
+{
+	perror("There was an error with open(). ");
+	exit(1); //The file already exists
+}
+```
+This code will create a file called "testfile" with user-read and user-write permissions granted to it, so that the user of the computer will be able to edit the file later on in future use.
+
+The system call `creat` is a variation of `open`, and is equivalent to the code below with the only two argument types:
+```
+open(//file descriptor, O_CREAT | O_WRONLY | O_TRUNC, //modes)
+```
+
+##read
+
+**includes:** `#include <unistd.h>`
+
+**declaration:** `ssize_t read(int fd, void *buf, size_t count);`
+
+**returns:** Returns a -1 if no bytes are read, and returns the number of bytes read on success. Will also return a 0 if no bytes are read, indicating the end of a file.
+
+[man page](http://linux.die.net/man/2/read)
+
+The `read` system call will take in a file descriptor, and pass its contents into the buffer assigned. The amount of bytes passed into the buffer from the file descriptor is dependent on the numerical value passed into the third argument.
+
+The `read` system call is special in that it can pick up and resume from where its previous stopping point ended if `read` is called again with the same buffer and file descriptor. It is possible to then transport an entire file descriptor into a buffer with subsequent calls of `read` with varying `count` values. In turn, it is also possible to transport an entire file descriptor into a buffer with just one call of `read`, if the amount of bytes to be read covered the entire scope of the file descriptor.
+
+An example of using `read` to place the contents of a file descriptor into a buffer:
+```
+int fd;
+if(-1 == (fd = open("examplefile", O_RDONLY)))
+{
+	perror("There was an error with open(). ");
+	exit(1); //Invalid permissions to create a file descriptor, file does not exist
+}
+
+int size;
+char c[BUFSIZ]; //The buffer of size BUFSIZ, which will be the size of the resulting file descriptor
+if(-1 == (size = read(fd, c, sizeof(c))))
+{
+	perror("There was an error with read(). ");
+	exit(1); //Invalid file descriptor or permissions, invalid buffer, or invalid byte value
+}
+while(size > 0)
+{
+	if(-1 == (size = read(fd, c, sizeof(c))))
+	{
+		perror("There was an error with read(). ");
+		exit(1); //Invalid file descriptor or permissions, invalid buffer, or invalid byte value
+	}
+}
+```
+
+##write
+
+**includes:** `#include <unistd.h>`
+
+**declaration:** `ssize_t write(int fd, const void *buf, size_t count);`
+
+**returns:** Returns a -1 if an error occured. Otherwise, returns the number of bytes successfully written or a 0 if nothing was written.
+
+[man page](http://linux.die.net/man/2/write)
+
+The `write` system call will take in a buffer, and send its contents into a file referred to by its file descriptor. The amount of bytes written to the file from the buffer is dependent on the numerical value passed into the third argument.
+
+The `write` system call is also special in that it can also pick up and resume from where its previous stopping point ended if `write` is called again with the same buffer and file descriptor much like `read`. It is possible to then transport the contents of the entire buffer into a file with subsequent calls of `write` with varying `count` values. In turn, it is also possible to transport the entirety of a buffer into a file with just one call of `write`, if the amount of bytes to be written equaled the entire buffer in question.
+
+An example of using `write` to read from an available buffer to a file descriptor:
+```
+int fd; //We need an integer to place the file descriptor somewhere for future use
+if(-1 == (fd = open("testfile", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR)))
+{
+	perror("There was an error with open(). ");
+	exit(1);
+}
+
+ //Assume we already have a filled buffer c,
+if(-1 == write(fd, c, sizeof(c)))
+{
+	perror("There was an error with write(). ");
+	exit(1); //Invalid file descriptor or permissions, invalid buffer, or invalid byte size
+}
+```
+
+##close
+
+**includes:** `#include <unistd.h>`
+
+**declaration:** `int close(int fd);`
+
+**returns:** Returns a -1 if an error occured, or a 0 if the file descriptor was successfully closed.
+
+[man page](http://linux.die.net/man/2/close)
+
+The system call `close` closes the file descriptor passed in, so that it may not be available for editing in code beyond the `close` system call. Closing file descriptors is important as it not only frees up the value of the file descriptor for resource allocation, it also prevents any additional changes to be made to the descriptor from future code. At this point, the file descriptor acts based on what flags were assigned to it, such as creating/overwriting a file or appending to an existing one.
+
+An example of using the `close` system call:
+```
+if(-1 == close(fd))
+{
+	perror("There was an error with close(). ");
+	exit(1); //Invalid file descriptor
+}
+```
+In this code the file descriptor attached to the variable `fd` is closed. The value pertaining to the file descriptor is now freed, and can be used again for subsequent system calls.
+
+##Additional Resources
+
+* [Demonstration: Manipulating File Descriptors](./fd_demo.md)
+* [Bitwise Operators](../bitwise-ops/README.md)

--- a/textbook/assignment-help/syscalls/fd_demo.md
+++ b/textbook/assignment-help/syscalls/fd_demo.md
@@ -1,0 +1,139 @@
+#Demonstration: Manipulating File Descriptors
+
+This file contains a block of code that demonstrates how to use file descriptors to take the contents of a 27-byte sized file `fileold` and place them in a new file `filenew` of the same byte size. The code utilizes the system calls `open`, `read`, `write`, and `close`, as well as file descriptors and buffers that the above system calls manipulate. The source code without any comments is shown below. Explanations paired with code snippets will follow below to piece the process all together.
+
+##Source Code
+
+Assume we have `fileold`, which holds the contents:
+```
+this file is 27-bytes long.
+```
+
+```
+int fdnew;
+if(-1 == (fdnew = open("filenew", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR)))
+{
+	perror("There was an error with open(). ");
+	exit(1);
+}
+
+int fdold;
+if(-1 == (fdold = open("fileold", O_RDONLY))) 
+{
+	perror("There was an error with open(). ");
+	exit(1);
+}
+
+int size;
+char c[27];
+if(-1 == (size = read(fdold, c, sizeof(c)))) 
+{
+	perror("There was an error with read(). ");
+	exit(1);
+}
+while(size > 0)
+{
+	if(-1 == write(fdnew, c, size))
+	{
+		perror("There was an error with write(). ");
+		exit(1);
+	}
+	if(-1 == (size = read(fdold, c, sizeof(c))))
+	{
+		perror("There was an error with read(). ");
+		exit(1);
+	}
+}
+
+if(-1 == close(fdnew))
+{
+	perror("There was an error with close(). ");
+	exit(1);
+}
+
+if(-1 == close(fdold))
+{
+	perror("There was an error with close(). ");
+	exit(1);
+}
+```
+
+##Explanation
+
+If we wish to place the message within `fileold` into a new file, we must first allocate memory for a file descriptor. File descriptors are data structures similar to buffers represented by an integer value. To store a file descriptor, we must set an integer variable for it, and call the `open` system call to generate the file descriptor to the variable. By default, the `open` system call will set the file descriptor value to the lowest possible descriptor value available. We must also create a file descriptor for the old file to mesh with the system calls throughout the process.
+
+```
+int fdnew; //Stores the file descriptor, an integer-based reference to a file
+if(-1 == (fdnew = open("filenew", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR))) //Parameters and flags dictate what open will set how the file descriptor will react
+{
+	perror("There was an error with open(). ");
+	exit(1); //Not enough shared memory to allocate file descriptor
+}
+
+int fdold;
+if(-1 == (fdold = open("fileold", O_RDONLY))) //Sets file descriptor to old file
+{
+	perror("There was an error with open(). ");
+	exit(1);
+}
+```
+
+`open` can take in 3 arguments; the file-name of the file descriptor is referencing to, the flags, and the modes that will determine the end-behavior of the file descriptor. The name passed in can be one that exists or not, depending on the flags and modes. The flags and modes are all octal values that have been conveniently defined into macros from the associated `open` libraries. These octal values are able to be appended together with the `|` bitwise operator.
+
+The flags `O_WRONLY | O_CREAT` tells `open` to ask the system for write permissions to create a file called `filenew`. The flag `ORDONLY` tells `open` to ask the system only for read permissions to the existing file `fileold`.
+
+The modes `S_IRUSR | S_IWUSR` define the permissions to the created file as read-able and write-able by the user.
+
+Once we have created the file descriptors, we can place the contents of `oldfile` into a buffer using `read`. From there, we take the contents of the buffer and `write` it in to the file descriptor referencing the new file. We will use a separate buffer and an integer to keep track of the transferred content across both files.
+
+```
+int size;
+char c[27]; //Sets the buffer equal to the size of `fileold`.
+if(-1 == (size = read(fdold, c, sizeof(c)))) //This function will set size to the value 27 for the number of bytes read was equal to the array c, which was 27
+{
+	perror("There was an error with read(). ");
+	exit(1); //Invalid file descriptor or permissions, invalid buffer, or invalid byte value
+}
+while(size > 0) //Loop to run read for situations where read does not read the entirety of a file
+{
+	if(-1 == write(fdnew, c, size)) //Writes to the new file the contents of the old file
+	{
+		perror("There was an error with write(). ");
+		exit(1); //Invalid file descriptor or permissions, invalid buffer, or invalid byte size
+	}
+	if(-1 == (size = read(fdold, c, sizeof(c)))) //Calls read again to update size and continue passing in the amount of bytes equal to the array's size from the old file if any
+	{
+		perror("There was an error with read(). ");
+		exit(1); //Invalid file descriptor or permissions, invalid buffer, or invalid byte value
+	}
+}
+```
+
+The `read` system call takes 3 arguments: the file descriptor to obtain data from, the buffer to send that data to, and how many bytes of data should be sent to the buffer. The amount of bytes that can be read range from just 1 byte to a recommend value given through the system, defined by the macro `BUFSIZ`.
+
+The `write` system call also takes 3 arguments: the file descriptor to write data to, the buffer to parse the data from, and the amount of content through bytes to be passed onto the file descriptor. The amount of bytes written range from just 1 byte to a recommended value given through the system, defined by the macro `BUFSIZ`.
+
+The usage of `read` and `write` exist in a loop due to how the `read` system call works. If `read` is called again with the same file descriptor and buffer to read to, the system call will simply pick up where it left off and read up to the amount of bytes given plus the amount of bytes previously given into the buffer. The loop acts as a way to continuously read through a file, as `read` will only return `0` or a negative value upon reaching the end of a file or an error. `write` also behaves in a similar way, with subsequent calls of `write` appending and not overwriting what was already written to the file descriptor from `read`.
+
+Once the loop ends, it is good practice to close the related file descriptors to `fileold` and `filenew`: `fdold`, and `fdnew`. Closing file descriptors frees up memory and also prevents unexpected behavior occurring to any files associated with file descriptors. Closing file descriptors also finalize any changes made to file descriptors before being made into a new file by the aftereffects of the `open` system call.
+
+```
+if(-1 == close(fdnew)) //Close file descriptor to create the file
+{
+	perror("There was an error with close(). ");
+	exit(1);
+}
+
+if(-1 == close(fdold)) //close file descriptor to conserve memory
+{
+	perror("There was an error with close(). ");
+	exit(1);
+}
+```
+
+If we were to check the same directory of this code, we would find a new file `filenew` with the message "`this file is 27-bytes long.`" contained within. This is the same message that was in `fileold`.
+
+##Follow-Up
+
+This demonstration only covers the use of `open`, `read`, `write`, and `close` system calls to create file descriptors that will result in a new file. Further documentation can be found here:
+* [System calls related to changing file descriptors](./fd.md)

--- a/textbook/assignment-help/syscalls/stat.md
+++ b/textbook/assignment-help/syscalls/stat.md
@@ -1,0 +1,105 @@
+#System calls to get the status of a file
+
+This document contains information on how to get the status of a file. The system calls described here are `stat`, `fstat`, and `lstat`.
+
+## What does stat, fstat, and lstat do?
+`stat`, `fstat`, and `lstat` obtain information of a file. All three return a `stat` structure when successful.
+
+The `stat` structure is as follows:
+```
+struct stat {
+               dev_t     st_dev;         /* ID of device containing file */
+               ino_t     st_ino;         /* inode number */
+               mode_t    st_mode;        /* protection */
+               nlink_t   st_nlink;       /* number of hard links */
+               uid_t     st_uid;         /* user ID of owner */
+               gid_t     st_gid;         /* group ID of owner */
+               dev_t     st_rdev;        /* device ID (if special file) */
+               off_t     st_size;        /* total size, in bytes */
+               blksize_t st_blksize;     /* blocksize for filesystem I/O */
+               blkcnt_t  st_blocks;      /* number of 512B blocks allocated */
+               time_t    st_atime;       /* time of last access */
+               time_t    st_mtime;       /* time of last modification */
+               time_t    st_ctime;       /* time of last status change */
+};
+```
+####Returns:
+As mentioned above, a `stat` structure is returned upon sucess. If an error occurs, -1 is returned.
+
+####Headers:
+`#include <sys/types.h>` `#include <sys/stat.h>`  `#include <unistd.h>`
+
+####Declaration:
+- stat: `int stat(const char*pathname, struct stat *buf);`
+- fstat: `int stat(int fd, struct stat *buf);`
+- lstat: `int stat(const char*pathname, struct stat *buf);`
+
+####[Man Page](http://linux.die.net/man/2/stat)
+
+##Example
+####Calling stat
+**stat**
+```
+struct stat buf; 	// create a stat struct to store file status
+const char* path; 	// name of the path where the file is located
+stat (path, &buf); 	// call stat (no error check)
+```
+
+**fstat**
+Instead of a pathname, `fstat` uses a file descriptor to stat. You can obtain a file descriptor by using the `open` syscall. (See the [file descriptors section](./fd.md))  on how to use it.)
+```
+struct stat buf;  	 // create a stat struct
+int fd; 			// file descriptor (obtained from open syscall)
+fstat (fd, &buf); 	// call fstat (no error check)
+```
+
+**lstat**
+In this case, the pathname used in `lstat` is a symbolic link. Because of this, `lstat` returns information about that link and not the file itself.
+```
+struct stat buf;		// create a stat struct
+const char* symLink;	// name of symbolic link
+lstat (symLink, &buf);	// call lstat (no error check)
+```
+####Obtaining information from stat
+After successfully calling `stat`, you can now obtain information about it. Remember the `stat` structure mentioned earlier? We will be using parts of that structure to get the info we need.
+
+Let's say that you want to know about the file's permissions. We can use the `st_mode` field and [Bitwise Operators](../bitwise-ops/README.md) to do so.
+
+For example, we can determine if the owner has read permissions on a file stat `fStat`:
+```
+struct stat fStat; // assume stat was successful (no error)
+
+if (fStat.st_mode & S_IRUSR) // bitwise ops is used here
+  cout << "The owner has read permissions";
+else
+  cout << "Owner does NOT have read permissions"
+```
+Similarily, you can do bitwise ops with the `st_mode` field to obtain info about the other permissions. Below is a list of some of them.
+
+Flag    | Permission
+------- | ------------------------------
+S_IRUSR | Owner has read permission
+S_IWUSR | Owner has write permission
+S_IXUSR | Owner has execute permission
+S_IRGRP | Group has read permission
+S_IWGRP | Group has write permission
+S_IXGRP | Group has execute permission
+S_IROTH | Others have read permission
+S_IWOTH | Others have write permission
+S_IXOTH | Others have execute permission
+
+Besides the `st_mode` field, you can access the other fields to obtain information about the file.
+
+## Summary
+In conclusion, here's how the `stat` syscall works:
+
+1. Create an empty `stat` structure to store the stat.
+2. Get stat by calling it:
+  - If you have a path name:
+    - Path name is NOT a symbolic link:
+      - use `stat()`
+    - Path name is a symbolic link:
+      - use `lstat()`
+  - If you have a file descriptor (obtained from using `open`):
+    - use `fstat()`
+3. Obtain information from the stat (i.e. `fStat.st_mode`) and use bitwise ops if necessary.


### PR DESCRIPTION
We split our syscall tutorials into two sections - a more traditional explanation of each system call, and an overarching demonstration to show the syscalls in action. Edited the syscall README, bitwise operators tutorial README, and the lab5 README to reflect the addition of these tutorial features. Included reference links that connect the tutorials together.

This is by no means a final submission; we'd like to hear your input on the addition of these `demos` and which format would be the most healthy and reasonable way to introduce these tutorial features. `dir.md` and `fd.md` each have their `demos` in separate files(`dir_demo.md`, `fd_demo.md`), with references to its sister files in the catergories `Follow-Up`/`Additional Resources` at the end of each file. `stat.md` encompasses both the demo and the documentation all in a single file. After critque, we'll polish up the files to use one format setting and submit that over the weekend as a final submission.

I worked with Lila Jomok (Github ID: goninety) on this submission. -Jeffrey Ng(GIthub ID: jng017)
