### PR TITLE
fixed the link for writing makefiles

### DIFF
--- a/assignments/hw/hw0-rshell/README.md
+++ b/assignments/hw/hw0-rshell/README.md
@@ -280,4 +280,4 @@ Here is a complete list of resources created by previous cs100 students that mig
 
 * [the Markdown formatting language](../../../textbook/bestpractices/WritingREADMEs/Markdown.md)
 
-* [writing Makefiles](../../../textbook/tools/Makefiles/README.md)
+* [writing Makefiles](../../../textbook/tools/make/README.md)


### PR DESCRIPTION
The link for "writing makefiles" was corrected.
Previously was: "https://github.com/mikeizbicki/ucr-cs100/blob/2015spring/textbook/tools/Makefiles/README.md"
Fixed to: "https://github.com/mikeizbicki/ucr-cs100/blob/2015spring/textbook/tools/make/README.md"
