### PR TITLE
changed broken link

### DIFF
--- a/assignments/hw/hw1-ls/README.md
+++ b/assignments/hw/hw1-ls/README.md
@@ -90,7 +90,7 @@ Here is a complete list of resources created by previous cs100 students that mig
 
 * [how to use syscalls](../../../textbook/assignment-help/syscalls)
 
-* [STL Map](../../../textbook/map)
+* [STL Map](../../../textbook/C++/stl-map)
 
 * video: [how to use the `ls` command](https://izbicki.me/blog/videoguide-for-github-vim-bash.html#ls).
 


### PR DESCRIPTION
fixed broken link - led to `../../../textbook/map` which didn't work to `../../../textbook/C++/stl-map` which works
