### PR TITLE
fixed download GDB link

### DIFF
--- a/textbook/tools/gdb/README.md
+++ b/textbook/tools/gdb/README.md
@@ -11,7 +11,7 @@ GDB is the debugger that runs on many Unix-like systems which allows the user to
 
 To download and install GDB, click on the following links:
 
-[Download GDB](www.gnu.org/software/gdb/download/)
+[Download GDB](http://www.gnu.org/software/gdb/download/)
 
 [How to Install](http://www.tutorialspoint.com/gnu_debugger/installing_gdb.htm)
 


### PR DESCRIPTION
GDB link doesn't work and leads to a github 404 error.
I added "http://" which fixed the link
