### PR TITLE
Added closing statement in parent 2

### DIFF
--- a/textbook/assignment-help/syscalls/io.md
+++ b/textbook/assignment-help/syscalls/io.md
@@ -137,6 +137,8 @@ else if(pid > 0) //first parent function
    }
    else if(pid2 > 0) //second parent function
    {
+      if (-1 == close(fd[PIPE_WRITE])) //close the write end of the pipe in the parent so the second child isn't left waiting
+         perror("There was an error with close. ");
       if(-1 == wait(0)) //wait for the child process to finish executing
          perror("There was an error with wait(). ");
    }


### PR DESCRIPTION
Need to close write end of pipe in second parent so the child of that process is not left waiting for input from write end of pipe. I was playing around with the code on here and I was wondering for the longest time why after my second `execvp()` the program was dangling.

I tested using: `ls -al | cat` which should have outputted whatever ls -al did, which it did, but it also left the program constantly asking for input.

Source: http://stackoverflow.com/questions/5610184/input-redirection-problem-while-using-execvp
